### PR TITLE
Fix ControllerGroup Indexing for Split Groups

### DIFF
--- a/src/client/group.rs
+++ b/src/client/group.rs
@@ -12,12 +12,16 @@ pub trait ControllerIndex {
     fn controller_id(&self) -> usize;
     /// Returns a reference to the controller with the given index.
     fn index<'a>(&self, group: &'a ControllerGroup) -> OpenRgbResult<&'a Controller> {
-        group.controllers.get(self.controller_id()).ok_or_else(|| {
-            OpenRgbError::CommandError(format!(
-                "Controller with index {} not found",
-                self.controller_id()
-            ))
-        })
+        group
+            .controllers
+            .iter()
+            .find(|controller| controller.id() == self.controller_id())
+            .ok_or_else(|| {
+                OpenRgbError::CommandError(format!(
+                    "Controller with index {} not found",
+                    self.controller_id()
+                ))
+            })
     }
     /// Removes the controller with the given index from the group and returns it.
     fn remove(&self, group: &mut ControllerGroup) -> OpenRgbResult<Controller> {

--- a/src/client/group.rs
+++ b/src/client/group.rs
@@ -215,4 +215,33 @@ mod tests {
         }
         Ok(())
     }
+
+    #[tokio::test]
+    #[ignore = "can only test with openrgb running"]
+    async fn test_group_index() -> OpenRgbResult<()> {
+        let client = OpenRgbClient::connect().await?;
+        let group = client.get_all_controllers().await?;
+        for (idx, controller) in group.iter().enumerate() {
+            assert_eq!(controller.controller_id(), idx);
+            assert_eq!(controller.index(&group)?, controller);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "can only test with openrgb running"]
+    async fn test_per_type_index() -> OpenRgbResult<()> {
+        let client = OpenRgbClient::connect().await?;
+        let group = client.get_all_controllers().await?;
+        let split = group.split_per_type();
+        for (device_type, controllers) in split {
+            println!("Device type: {device_type:?}");
+            for controller in controllers.controllers() {
+                println!("  Controller: {} ({})", controller.name(), controller.id());
+                assert_eq!(controller.index(&controllers)?, controller);
+            }
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
After splitting a ControllerGroup by type, a subgroup can contain a Controller with an ID larger than the len of the controllers Vec.
When passing such a controller to CommandGroup.set_controller_led() where the CommandGroup comes from a subgroup, set_controller_led will return an Error despite the controller being valid and available.

This PR fixes that by replacing `self.controllers.get()` with `self.controllers.iter().find()` in ControllerIndex.index().
This makes index() run in O(n) rather than O(1). The other option would be to update the controller ID when split into a subgroup or track its index in a separate variable, but that seemed to add more complexity than it was worth.